### PR TITLE
[v0.3.1] Add migration for revoked tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ ECWT is module for creating and verifying encrypted CBOR Web Tokens. It is desig
 ECWT depends on other modules, so you need to install them too.
 
 ```sh
-npm install ecwt @kirick/snowflake
+bun install ecwt @kirick/snowflake
 # or
 pnpm install ecwt @kirick/snowflake
 # or
-bun install ecwt @kirick/snowflake
+npm install ecwt @kirick/snowflake
 ```
 
 ### Some dependencies

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "typescript": "6.0.2",
         "unplugin-unused": "0.5.7",
         "valibot": "1.4.0",
-        "vitest": "4.1.6",
+        "vitest": "4.1.7",
       },
       "peerDependencies": {
         "@kirick/snowflake": "^0.3",
@@ -79,6 +79,58 @@
     "@es-joy/jsdoccomment": ["@es-joy/jsdoccomment@0.86.0", "", { "dependencies": { "@types/estree": "^1.0.8", "@typescript-eslint/types": "^8.58.0", "comment-parser": "1.4.6", "esquery": "^1.7.0", "jsdoc-type-pratt-parser": "~7.2.0" } }, "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw=="],
 
     "@es-joy/resolve.exports": ["@es-joy/resolve.exports@1.2.0", "", {}, "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -208,6 +260,56 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
     "@sindresorhus/base62": ["@sindresorhus/base62@1.0.0", "", {}, "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -250,19 +352,19 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
+    "@vitest/expect": ["@vitest/expect@4.1.7", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.7", "", { "dependencies": { "@vitest/spy": "4.1.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.7", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
+    "@vitest/runner": ["@vitest/runner@4.1.7", "", { "dependencies": { "@vitest/utils": "4.1.7", "pathe": "^2.0.3" } }, "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "@vitest/utils": "4.1.7", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
+    "@vitest/spy": ["@vitest/spy@4.1.7", "", {}, "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -339,6 +441,8 @@
     "enhanced-resolve": ["enhanced-resolve@5.21.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -448,30 +552,6 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
-
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
-
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
-
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
-
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
-
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
-
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
-
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
-
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
-
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
-
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
-
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
-
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
@@ -550,6 +630,8 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
@@ -620,9 +702,9 @@
 
     "valibot": ["valibot@1.4.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg=="],
 
-    "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
 
-    "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
+    "vitest": ["vitest@4.1.7", "", { "dependencies": { "@vitest/expect": "4.1.7", "@vitest/mocker": "4.1.7", "@vitest/pretty-format": "4.1.7", "@vitest/runner": "4.1.7", "@vitest/snapshot": "4.1.7", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.7", "@vitest/browser-preview": "4.1.7", "@vitest/browser-webdriverio": "4.1.7", "@vitest/coverage-istanbul": "4.1.7", "@vitest/coverage-v8": "4.1.7", "@vitest/ui": "4.1.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA=="],
 
     "vue-eslint-parser": ["vue-eslint-parser@10.4.0", "", { "dependencies": { "debug": "^4.4.0", "eslint-scope": "^8.2.0 || ^9.0.0", "eslint-visitor-keys": "^4.2.0 || ^5.0.0", "espree": "^10.3.0 || ^11.0.0", "esquery": "^1.6.0", "semver": "^7.6.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg=="],
 
@@ -668,42 +750,8 @@
 
     "rolldown-plugin-dts/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
 
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
     "unplugin-unused/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
-
-    "vite/rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
-
-    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
-
-    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
-
-    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
-
-    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
-
-    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
-
-    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
-
-    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
-
-    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
-
-    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
-
-    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
-
-    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
-
-    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
-
-    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
   }
 }

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -59,8 +59,8 @@ var Ecwt = class {
 	snowflake;
 	/** Data stored in token. */
 	data;
-	ecwtFactory;
-	ttl_initial;
+	#ecwtFactory;
+	#ttl_initial;
 	/**
 	* @param ecwtFactory -
 	* @param options -
@@ -74,28 +74,28 @@ var Ecwt = class {
 		this.id = options.snowflake.toBase62();
 		this.snowflake = options.snowflake;
 		this.data = Object.freeze(options.data);
-		this.ecwtFactory = ecwtFactory;
-		this.ttl_initial = options.ttl_initial;
+		this.#ecwtFactory = ecwtFactory;
+		this.#ttl_initial = options.ttl_initial;
 	}
 	/**
 	* Unix timestamp of token expiration in seconds.
 	* @returns -
 	*/
 	get ts_expired() {
-		if (this.ttl_initial === null) return null;
-		return Math.floor(this.snowflake.timestamp / 1e3) + this.ttl_initial;
+		if (this.#ttl_initial === null) return null;
+		return Math.floor(this.snowflake.timestamp / 1e3) + this.#ttl_initial;
 	}
 	/**
 	* Actual time to live in seconds.
 	* @returns -
 	*/
 	getTTL() {
-		if (this.ttl_initial === null) return null;
-		return this.ttl_initial - Math.floor((Date.now() - this.snowflake.timestamp) / 1e3);
+		if (this.#ttl_initial === null) return null;
+		return this.#ttl_initial - Math.floor((Date.now() - this.snowflake.timestamp) / 1e3);
 	}
 	/** Revokes token. */
 	revoke() {
-		return this.ecwtFactory._revoke(this.id, this.snowflake.timestamp, this.ttl_initial);
+		return this.#ecwtFactory._revoke(this.id, this.snowflake.timestamp, this.#ttl_initial);
 	}
 };
 //#endregion
@@ -105,21 +105,21 @@ const base62 = (0, base_x.default)("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
 //#region src/factory.ts
 const REDIS_PREFIX = "@ecwt:";
 var EcwtFactory = class {
-	redisClient;
-	lruCache;
-	snowflakeFactory;
-	redis_key_revoked;
-	encryption_key;
-	validator;
-	cborEncoder = null;
+	#redisClient;
+	#lruCache;
+	#snowflakeFactory;
+	#redis_key_revoked;
+	#encryption_key;
+	#validator;
+	#cborEncoder = null;
 	constructor({ redisClient, lruCache, snowflakeFactory, options }) {
-		this.redisClient = redisClient;
-		this.lruCache = lruCache;
-		this.snowflakeFactory = snowflakeFactory;
-		this.redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
-		this.encryption_key = options.key;
-		this.validator = options.validator;
-		if (options.senml_key_map) this.cborEncoder = new cbor_x.Encoder({ keyMap: options.senml_key_map });
+		this.#redisClient = redisClient;
+		this.#lruCache = lruCache;
+		this.#snowflakeFactory = snowflakeFactory;
+		this.#redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
+		this.#encryption_key = options.key;
+		this.#validator = options.validator;
+		if (options.senml_key_map) this.#cborEncoder = new cbor_x.Encoder({ keyMap: options.senml_key_map });
 	}
 	/**
 	* Creates new token.
@@ -130,16 +130,16 @@ var EcwtFactory = class {
 	* @returns -
 	*/
 	async create(data, options = {}) {
-		if (typeof this.validator === "function") data = this.validator(data);
+		if (typeof this.#validator === "function") data = this.#validator(data);
 		const ttl = options.ttl ?? null;
-		const snowflake = await this.snowflakeFactory.createSafe();
+		const snowflake = await this.#snowflakeFactory.createSafe();
 		const payload = [
 			snowflake.toBuffer(),
 			ttl,
 			data
 		];
-		const token_raw = this.cborEncoder ? this.cborEncoder.encode(payload) : (0, cbor_x.encode)(payload);
-		const token_encrypted = await evilcrypt.v2.encrypt(token_raw, this.encryption_key);
+		const token_raw = this.#cborEncoder ? this.#cborEncoder.encode(payload) : (0, cbor_x.encode)(payload);
+		const token_encrypted = await evilcrypt.v2.encrypt(token_raw, this.#encryption_key);
 		const token = base62.encode(token_encrypted);
 		this.setCache(token, {
 			snowflake,
@@ -160,7 +160,7 @@ var EcwtFactory = class {
 	*/
 	setCache(token, cache_value) {
 		var _this$lruCache;
-		(_this$lruCache = this.lruCache) === null || _this$lruCache === void 0 || _this$lruCache.set(token, cache_value, cache_value.ttl_initial === null ? void 0 : { ttl: cache_value.ttl_initial * 1e3 });
+		(_this$lruCache = this.#lruCache) === null || _this$lruCache === void 0 || _this$lruCache.set(token, cache_value, cache_value.ttl_initial === null ? void 0 : { ttl: cache_value.ttl_initial * 1e3 });
 	}
 	/**
 	* Parses token.
@@ -168,26 +168,26 @@ var EcwtFactory = class {
 	* @returns -
 	*/
 	async verify(token) {
-		var _this$lruCache2, _this$redisClient;
+		var _this$lruCache2;
 		if (typeof token !== "string") throw new TypeError("Token must be a string.");
 		let snowflake;
 		let ttl_initial;
 		let data;
-		const cached_entry = (_this$lruCache2 = this.lruCache) === null || _this$lruCache2 === void 0 ? void 0 : _this$lruCache2.info(token);
+		const cached_entry = (_this$lruCache2 = this.#lruCache) === null || _this$lruCache2 === void 0 ? void 0 : _this$lruCache2.info(token);
 		if (cached_entry === void 0) {
 			const token_encrypted = Buffer.from(base62.decode(token));
 			let token_raw;
 			try {
-				token_raw = await (0, evilcrypt.decrypt)(token_encrypted, this.encryption_key);
+				token_raw = await (0, evilcrypt.decrypt)(token_encrypted, this.#encryption_key);
 			} catch {
 				throw new EcwtParseError();
 			}
-			const payload = this.cborEncoder ? this.cborEncoder.decode(token_raw) : (0, cbor_x.decode)(token_raw);
+			const payload = this.#cborEncoder ? this.#cborEncoder.decode(token_raw) : (0, cbor_x.decode)(token_raw);
 			const [snowflake_buffer] = payload;
 			[, ttl_initial, data] = payload;
-			snowflake = this.snowflakeFactory.parse(snowflake_buffer);
-			if (typeof this.validator === "function") try {
-				data = this.validator(data);
+			snowflake = this.#snowflakeFactory.parse(snowflake_buffer);
+			if (typeof this.#validator === "function") try {
+				data = this.#validator(data);
 			} catch {
 				throw new EcwtParseError();
 			}
@@ -204,7 +204,10 @@ var EcwtFactory = class {
 			data
 		});
 		if (typeof ttl_initial === "number" && Number.isNaN(ttl_initial) !== true && snowflake.timestamp + ttl_initial * 1e3 < Date.now()) throw new EcwtExpiredError(ecwt);
-		if (await ((_this$redisClient = this.redisClient) === null || _this$redisClient === void 0 ? void 0 : _this$redisClient.HEXISTS(this.redis_key_revoked, ecwt.id))) throw new EcwtRevokedError(ecwt);
+		if (this.#redisClient) {
+			await this.#migrateExpired();
+			if (await this.#redisClient.HEXISTS(this.#redis_key_revoked, ecwt.id)) throw new EcwtRevokedError(ecwt);
+		}
 		return ecwt;
 	}
 	/**
@@ -234,29 +237,46 @@ var EcwtFactory = class {
 	}
 	/**
 	* Revokes token.
+	* @internal
 	* @param token_id -
-	* @param ts_ms_created -
+	* @param created_at_ms -
 	* @param ttl_initial -
 	* @returns -
 	*/
-	async _revoke(token_id, ts_ms_created, ttl_initial) {
-		if (this.redisClient) {
-			ttl_initial ??= Number.MAX_SAFE_INTEGER;
-			const ts_ms_expired = ts_ms_created + ttl_initial * 1e3;
-			if (ts_ms_expired > Date.now()) await this.redisClient.sendCommand([
-				"HSET",
-				this.redis_key_revoked,
-				token_id,
-				"",
-				"PX",
-				String(ts_ms_expired - Date.now())
-			]);
+	async _revoke(token_id, created_at_ms, ttl_initial) {
+		if (this.#redisClient) {
+			await this.#migrateExpired();
+			if (ttl_initial === null) await this.#redisClient.HSET(this.#redis_key_revoked, token_id, "");
+			else {
+				const expires_in_ms = created_at_ms + ttl_initial * 1e3 - Date.now();
+				if (expires_in_ms > 0) await this.#redisClient.sendCommand([
+					"HSET",
+					this.#redis_key_revoked,
+					token_id,
+					"",
+					"PX",
+					String(expires_in_ms)
+				]);
+			}
 		} else console.warn("[ecwt] Redis client is not provided. Tokens cannot be revoked.");
 	}
-	/** Purges LRU cache. */
+	#migrated = false;
+	async #migrateExpired() {
+		if (this.#redisClient && !this.#migrated) {
+			await this.#redisClient.EVAL("local key = KEYS[1] if redis.call(\"TYPE\", key)[\"ok\"] ~= \"zset\" then return end local key_hash = key .. \":hash\" local ts_now = tonumber(ARGV[1]) local cursor = \"0\" repeat local scan = redis.call(\"ZSCAN\", key, cursor, \"COUNT\", 1000) cursor = scan[1] local items = scan[2] for i = 1, #items, 2 do local field = items[i] local expire_at = tonumber(items[i + 1]) local expire_in = expire_at and expire_at - ts_now redis.call(\"HSET\", key_hash, field, \"\") if expire_in and expire_in > 0 then redis.call(\"HPEXPIRE\", key_hash, expire_in, \"FIELDS\", 1, field) end end until cursor == \"0\" redis.call(\"DEL\", key) redis.call(\"RENAME\", key_hash, key)", {
+				keys: [this.#redis_key_revoked],
+				arguments: [String(Date.now())]
+			});
+			this.#migrated = true;
+		}
+	}
+	/**
+	* @internal
+	* Purges LRU cache.
+	*/
 	_purgeCache() {
 		var _this$lruCache3;
-		(_this$lruCache3 = this.lruCache) === null || _this$lruCache3 === void 0 || _this$lruCache3.clear();
+		(_this$lruCache3 = this.#lruCache) === null || _this$lruCache3 === void 0 || _this$lruCache3.clear();
 	}
 };
 //#endregion

--- a/dist/main.d.cts
+++ b/dist/main.d.cts
@@ -21,13 +21,7 @@ type EcwtFactoryArguments<D extends Record<string, unknown>> = {
   };
 };
 declare class EcwtFactory<const D extends Record<string, unknown> = Record<string, unknown>> {
-  private redisClient;
-  private lruCache;
-  private snowflakeFactory;
-  private redis_key_revoked;
-  private encryption_key;
-  private validator;
-  private cborEncoder;
+  #private;
   constructor({
     redisClient,
     lruCache,
@@ -69,20 +63,11 @@ declare class EcwtFactory<const D extends Record<string, unknown> = Record<strin
     success: false;
     ecwt: Ecwt<D> | null;
   }>;
-  /**
-  * Revokes token.
-  * @param token_id -
-  * @param ts_ms_created -
-  * @param ttl_initial -
-  * @returns -
-  */
-  private _revoke;
-  /** Purges LRU cache. */
-  private _purgeCache;
 }
 //#endregion
 //#region src/token.d.ts
 declare class Ecwt<const D extends Record<string, unknown> = Record<string, unknown>> {
+  #private;
   /** Token string representation. */
   readonly token: string;
   /** Token ID. */
@@ -91,8 +76,6 @@ declare class Ecwt<const D extends Record<string, unknown> = Record<string, unkn
   readonly snowflake: Snowflake;
   /** Data stored in token. */
   readonly data: Readonly<D>;
-  private ecwtFactory;
-  private ttl_initial;
   /**
   * @param ecwtFactory -
   * @param options -

--- a/dist/main.d.mts
+++ b/dist/main.d.mts
@@ -21,13 +21,7 @@ type EcwtFactoryArguments<D extends Record<string, unknown>> = {
   };
 };
 declare class EcwtFactory<const D extends Record<string, unknown> = Record<string, unknown>> {
-  private redisClient;
-  private lruCache;
-  private snowflakeFactory;
-  private redis_key_revoked;
-  private encryption_key;
-  private validator;
-  private cborEncoder;
+  #private;
   constructor({
     redisClient,
     lruCache,
@@ -69,20 +63,11 @@ declare class EcwtFactory<const D extends Record<string, unknown> = Record<strin
     success: false;
     ecwt: Ecwt<D> | null;
   }>;
-  /**
-  * Revokes token.
-  * @param token_id -
-  * @param ts_ms_created -
-  * @param ttl_initial -
-  * @returns -
-  */
-  private _revoke;
-  /** Purges LRU cache. */
-  private _purgeCache;
 }
 //#endregion
 //#region src/token.d.ts
 declare class Ecwt<const D extends Record<string, unknown> = Record<string, unknown>> {
+  #private;
   /** Token string representation. */
   readonly token: string;
   /** Token ID. */
@@ -91,8 +76,6 @@ declare class Ecwt<const D extends Record<string, unknown> = Record<string, unkn
   readonly snowflake: Snowflake;
   /** Data stored in token. */
   readonly data: Readonly<D>;
-  private ecwtFactory;
-  private ttl_initial;
   /**
   * @param ecwtFactory -
   * @param options -

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -35,8 +35,8 @@ var Ecwt = class {
 	snowflake;
 	/** Data stored in token. */
 	data;
-	ecwtFactory;
-	ttl_initial;
+	#ecwtFactory;
+	#ttl_initial;
 	/**
 	* @param ecwtFactory -
 	* @param options -
@@ -50,28 +50,28 @@ var Ecwt = class {
 		this.id = options.snowflake.toBase62();
 		this.snowflake = options.snowflake;
 		this.data = Object.freeze(options.data);
-		this.ecwtFactory = ecwtFactory;
-		this.ttl_initial = options.ttl_initial;
+		this.#ecwtFactory = ecwtFactory;
+		this.#ttl_initial = options.ttl_initial;
 	}
 	/**
 	* Unix timestamp of token expiration in seconds.
 	* @returns -
 	*/
 	get ts_expired() {
-		if (this.ttl_initial === null) return null;
-		return Math.floor(this.snowflake.timestamp / 1e3) + this.ttl_initial;
+		if (this.#ttl_initial === null) return null;
+		return Math.floor(this.snowflake.timestamp / 1e3) + this.#ttl_initial;
 	}
 	/**
 	* Actual time to live in seconds.
 	* @returns -
 	*/
 	getTTL() {
-		if (this.ttl_initial === null) return null;
-		return this.ttl_initial - Math.floor((Date.now() - this.snowflake.timestamp) / 1e3);
+		if (this.#ttl_initial === null) return null;
+		return this.#ttl_initial - Math.floor((Date.now() - this.snowflake.timestamp) / 1e3);
 	}
 	/** Revokes token. */
 	revoke() {
-		return this.ecwtFactory._revoke(this.id, this.snowflake.timestamp, this.ttl_initial);
+		return this.#ecwtFactory._revoke(this.id, this.snowflake.timestamp, this.#ttl_initial);
 	}
 };
 //#endregion
@@ -81,21 +81,21 @@ const base62 = basex("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv
 //#region src/factory.ts
 const REDIS_PREFIX = "@ecwt:";
 var EcwtFactory = class {
-	redisClient;
-	lruCache;
-	snowflakeFactory;
-	redis_key_revoked;
-	encryption_key;
-	validator;
-	cborEncoder = null;
+	#redisClient;
+	#lruCache;
+	#snowflakeFactory;
+	#redis_key_revoked;
+	#encryption_key;
+	#validator;
+	#cborEncoder = null;
 	constructor({ redisClient, lruCache, snowflakeFactory, options }) {
-		this.redisClient = redisClient;
-		this.lruCache = lruCache;
-		this.snowflakeFactory = snowflakeFactory;
-		this.redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
-		this.encryption_key = options.key;
-		this.validator = options.validator;
-		if (options.senml_key_map) this.cborEncoder = new Encoder({ keyMap: options.senml_key_map });
+		this.#redisClient = redisClient;
+		this.#lruCache = lruCache;
+		this.#snowflakeFactory = snowflakeFactory;
+		this.#redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
+		this.#encryption_key = options.key;
+		this.#validator = options.validator;
+		if (options.senml_key_map) this.#cborEncoder = new Encoder({ keyMap: options.senml_key_map });
 	}
 	/**
 	* Creates new token.
@@ -106,16 +106,16 @@ var EcwtFactory = class {
 	* @returns -
 	*/
 	async create(data, options = {}) {
-		if (typeof this.validator === "function") data = this.validator(data);
+		if (typeof this.#validator === "function") data = this.#validator(data);
 		const ttl = options.ttl ?? null;
-		const snowflake = await this.snowflakeFactory.createSafe();
+		const snowflake = await this.#snowflakeFactory.createSafe();
 		const payload = [
 			snowflake.toBuffer(),
 			ttl,
 			data
 		];
-		const token_raw = this.cborEncoder ? this.cborEncoder.encode(payload) : encode(payload);
-		const token_encrypted = await v2.encrypt(token_raw, this.encryption_key);
+		const token_raw = this.#cborEncoder ? this.#cborEncoder.encode(payload) : encode(payload);
+		const token_encrypted = await v2.encrypt(token_raw, this.#encryption_key);
 		const token = base62.encode(token_encrypted);
 		this.setCache(token, {
 			snowflake,
@@ -136,7 +136,7 @@ var EcwtFactory = class {
 	*/
 	setCache(token, cache_value) {
 		var _this$lruCache;
-		(_this$lruCache = this.lruCache) === null || _this$lruCache === void 0 || _this$lruCache.set(token, cache_value, cache_value.ttl_initial === null ? void 0 : { ttl: cache_value.ttl_initial * 1e3 });
+		(_this$lruCache = this.#lruCache) === null || _this$lruCache === void 0 || _this$lruCache.set(token, cache_value, cache_value.ttl_initial === null ? void 0 : { ttl: cache_value.ttl_initial * 1e3 });
 	}
 	/**
 	* Parses token.
@@ -144,26 +144,26 @@ var EcwtFactory = class {
 	* @returns -
 	*/
 	async verify(token) {
-		var _this$lruCache2, _this$redisClient;
+		var _this$lruCache2;
 		if (typeof token !== "string") throw new TypeError("Token must be a string.");
 		let snowflake;
 		let ttl_initial;
 		let data;
-		const cached_entry = (_this$lruCache2 = this.lruCache) === null || _this$lruCache2 === void 0 ? void 0 : _this$lruCache2.info(token);
+		const cached_entry = (_this$lruCache2 = this.#lruCache) === null || _this$lruCache2 === void 0 ? void 0 : _this$lruCache2.info(token);
 		if (cached_entry === void 0) {
 			const token_encrypted = Buffer.from(base62.decode(token));
 			let token_raw;
 			try {
-				token_raw = await decrypt(token_encrypted, this.encryption_key);
+				token_raw = await decrypt(token_encrypted, this.#encryption_key);
 			} catch {
 				throw new EcwtParseError();
 			}
-			const payload = this.cborEncoder ? this.cborEncoder.decode(token_raw) : decode(token_raw);
+			const payload = this.#cborEncoder ? this.#cborEncoder.decode(token_raw) : decode(token_raw);
 			const [snowflake_buffer] = payload;
 			[, ttl_initial, data] = payload;
-			snowflake = this.snowflakeFactory.parse(snowflake_buffer);
-			if (typeof this.validator === "function") try {
-				data = this.validator(data);
+			snowflake = this.#snowflakeFactory.parse(snowflake_buffer);
+			if (typeof this.#validator === "function") try {
+				data = this.#validator(data);
 			} catch {
 				throw new EcwtParseError();
 			}
@@ -180,7 +180,10 @@ var EcwtFactory = class {
 			data
 		});
 		if (typeof ttl_initial === "number" && Number.isNaN(ttl_initial) !== true && snowflake.timestamp + ttl_initial * 1e3 < Date.now()) throw new EcwtExpiredError(ecwt);
-		if (await ((_this$redisClient = this.redisClient) === null || _this$redisClient === void 0 ? void 0 : _this$redisClient.HEXISTS(this.redis_key_revoked, ecwt.id))) throw new EcwtRevokedError(ecwt);
+		if (this.#redisClient) {
+			await this.#migrateExpired();
+			if (await this.#redisClient.HEXISTS(this.#redis_key_revoked, ecwt.id)) throw new EcwtRevokedError(ecwt);
+		}
 		return ecwt;
 	}
 	/**
@@ -210,29 +213,46 @@ var EcwtFactory = class {
 	}
 	/**
 	* Revokes token.
+	* @internal
 	* @param token_id -
-	* @param ts_ms_created -
+	* @param created_at_ms -
 	* @param ttl_initial -
 	* @returns -
 	*/
-	async _revoke(token_id, ts_ms_created, ttl_initial) {
-		if (this.redisClient) {
-			ttl_initial ??= Number.MAX_SAFE_INTEGER;
-			const ts_ms_expired = ts_ms_created + ttl_initial * 1e3;
-			if (ts_ms_expired > Date.now()) await this.redisClient.sendCommand([
-				"HSET",
-				this.redis_key_revoked,
-				token_id,
-				"",
-				"PX",
-				String(ts_ms_expired - Date.now())
-			]);
+	async _revoke(token_id, created_at_ms, ttl_initial) {
+		if (this.#redisClient) {
+			await this.#migrateExpired();
+			if (ttl_initial === null) await this.#redisClient.HSET(this.#redis_key_revoked, token_id, "");
+			else {
+				const expires_in_ms = created_at_ms + ttl_initial * 1e3 - Date.now();
+				if (expires_in_ms > 0) await this.#redisClient.sendCommand([
+					"HSET",
+					this.#redis_key_revoked,
+					token_id,
+					"",
+					"PX",
+					String(expires_in_ms)
+				]);
+			}
 		} else console.warn("[ecwt] Redis client is not provided. Tokens cannot be revoked.");
 	}
-	/** Purges LRU cache. */
+	#migrated = false;
+	async #migrateExpired() {
+		if (this.#redisClient && !this.#migrated) {
+			await this.#redisClient.EVAL("local key = KEYS[1] if redis.call(\"TYPE\", key)[\"ok\"] ~= \"zset\" then return end local key_hash = key .. \":hash\" local ts_now = tonumber(ARGV[1]) local cursor = \"0\" repeat local scan = redis.call(\"ZSCAN\", key, cursor, \"COUNT\", 1000) cursor = scan[1] local items = scan[2] for i = 1, #items, 2 do local field = items[i] local expire_at = tonumber(items[i + 1]) local expire_in = expire_at and expire_at - ts_now redis.call(\"HSET\", key_hash, field, \"\") if expire_in and expire_in > 0 then redis.call(\"HPEXPIRE\", key_hash, expire_in, \"FIELDS\", 1, field) end end until cursor == \"0\" redis.call(\"DEL\", key) redis.call(\"RENAME\", key_hash, key)", {
+				keys: [this.#redis_key_revoked],
+				arguments: [String(Date.now())]
+			});
+			this.#migrated = true;
+		}
+	}
+	/**
+	* @internal
+	* Purges LRU cache.
+	*/
 	_purgeCache() {
 		var _this$lruCache3;
-		(_this$lruCache3 = this.lruCache) === null || _this$lruCache3 === void 0 || _this$lruCache3.clear();
+		(_this$lruCache3 = this.#lruCache) === null || _this$lruCache3 === void 0 || _this$lruCache3.clear();
 	}
 };
 //#endregion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ecwt",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Encrypted CBOR Web Token",
 	"publishConfig": {
 		"access": "public"
@@ -42,7 +42,7 @@
 		"typescript": "6.0.2",
 		"unplugin-unused": "0.5.7",
 		"valibot": "1.4.0",
-		"vitest": "4.1.6"
+		"vitest": "4.1.7"
 	},
 	"scripts": {
 		"build": "tsdown src/main.ts --format esm --format cjs --dts --publint --unused",

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -43,16 +43,20 @@ const dataSchema = v.strictObject({
 
 const validator = v.parser(dataSchema);
 
-const ecwtFactory = new EcwtFactory({
-	redisClient,
-	lruCache,
-	snowflakeFactory,
-	options: {
-		namespace: 'test',
-		key,
-		validator,
-	},
-});
+function createEcwtFactory() {
+	return new EcwtFactory({
+		redisClient,
+		lruCache,
+		snowflakeFactory,
+		options: {
+			namespace: 'test',
+			key,
+			validator,
+		},
+	});
+}
+
+const ecwtFactory = createEcwtFactory();
 
 async function measureTime(
 	fn: (...args: unknown[]) => unknown,
@@ -126,7 +130,6 @@ describe('create token', () => {
 			expect.unreachable();
 		}
 
-		// @ts-expect-error Accessing private method
 		ecwtFactory._purgeCache();
 
 		const ecwt_verified = await ecwtFactory.verify(ecwt.token);
@@ -146,7 +149,6 @@ describe('create token', () => {
 
 		const _ecwt = ecwt;
 
-		// @ts-expect-error Accessing private method
 		ecwtFactory._purgeCache();
 
 		const time_no_cache = await measureTime(async () => {
@@ -250,7 +252,6 @@ describe('token expiration', () => {
 			{ ttl: 1 },
 		);
 
-		// @ts-expect-error Accessing private method
 		ecwtFactory._purgeCache();
 
 		await new Promise((resolve) => {
@@ -289,7 +290,6 @@ describe('token revocation', () => {
 			{ ttl: 100 },
 		);
 
-		// @ts-expect-error Accessing private method
 		ecwtFactory._purgeCache();
 
 		await ecwt.revoke();
@@ -297,5 +297,91 @@ describe('token revocation', () => {
 		const promise = ecwtFactory.verify(ecwt.token);
 		await expect(promise).rejects.toThrow(EcwtRevokedError);
 		await expect(promise).rejects.toThrow(EcwtInvalidError);
+	});
+
+	describe('migration', () => {
+		const REDIS_KEY = '@ecwt:test:revoked';
+
+		test('actual migration', async () => {
+			await redisClient
+				.MULTI()
+				.DEL(REDIS_KEY)
+				.addCommand([
+					'ZADD',
+					REDIS_KEY,
+					String(Date.now() + 10_000),
+					'deadbeef',
+				])
+				.EXEC();
+
+			// we use a new factory to test that the "migrated" flag is cleared
+			const ecwtFactory2 = createEcwtFactory();
+
+			const ecwt = await ecwtFactory2.create(
+				{
+					user_id: 1,
+					nick: 'kirick',
+				},
+				{ ttl: 100 },
+			);
+
+			// force migration
+			await ecwtFactory2.verify(ecwt.token);
+
+			const type = await redisClient.TYPE(REDIS_KEY);
+			expect(type).toBe('hash');
+
+			const data = await redisClient.HGETALL(REDIS_KEY);
+			// redis client uses object with null prototype, breaking strict equality
+			// oh my god.
+			expect(structuredClone(data)).toStrictEqual({ deadbeef: '' });
+
+			const ttl = await redisClient.sendCommand([
+				'HPTTL',
+				REDIS_KEY,
+				'FIELDS',
+				'1',
+				'deadbeef',
+			]);
+			if (Array.isArray(ttl) !== true) {
+				throw new TypeError('ttl is not an array');
+			}
+
+			// console.info(ttl[0]);
+
+			expect(ttl[0]).toBeLessThan(10_000);
+			expect(ttl[0]).toBeGreaterThan(9000);
+		});
+
+		test('already migrated', async () => {
+			await redisClient
+				.MULTI()
+				.DEL(REDIS_KEY)
+				.HSET(REDIS_KEY, 'deadbeef', '')
+				.HPEXPIRE(REDIS_KEY, 'deadbeef', 10_000)
+				.EXEC();
+
+			// we use a new factory to test that the "migrated" flag is cleared
+			const ecwtFactory2 = createEcwtFactory();
+
+			const ecwt = await ecwtFactory2.create(
+				{
+					user_id: 1,
+					nick: 'kirick',
+				},
+				{ ttl: 100 },
+			);
+
+			// force migration
+			await ecwtFactory2.verify(ecwt.token);
+
+			const type = await redisClient.TYPE(REDIS_KEY);
+			expect(type).toBe('hash');
+
+			const data = await redisClient.HGETALL(REDIS_KEY);
+			// redis client uses object with null prototype, breaking strict equality
+			// oh my god.
+			expect(structuredClone(data)).toStrictEqual({ deadbeef: '' });
+		});
 	});
 });

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -51,13 +51,13 @@ const REDIS_PREFIX = '@ecwt:';
 export class EcwtFactory<
 	const D extends Record<string, unknown> = Record<string, unknown>,
 > {
-	private redisClient: RedisClient | undefined;
-	private lruCache: LRUCache<string, LRUCacheValue> | undefined;
-	private snowflakeFactory: SnowflakeFactory;
-	private redis_key_revoked: string;
-	private encryption_key: Buffer;
-	private validator: ((value: unknown) => D) | undefined;
-	private cborEncoder: CborEncoder | null = null;
+	#redisClient: RedisClient | undefined;
+	#lruCache: LRUCache<string, LRUCacheValue> | undefined;
+	#snowflakeFactory: SnowflakeFactory;
+	#redis_key_revoked: string;
+	#encryption_key: Buffer;
+	#validator: ((value: unknown) => D) | undefined;
+	#cborEncoder: CborEncoder | null = null;
 
 	constructor({
 		redisClient,
@@ -65,16 +65,16 @@ export class EcwtFactory<
 		snowflakeFactory,
 		options,
 	}: EcwtFactoryArguments<D>) {
-		this.redisClient = redisClient;
-		this.lruCache = lruCache;
-		this.snowflakeFactory = snowflakeFactory;
+		this.#redisClient = redisClient;
+		this.#lruCache = lruCache;
+		this.#snowflakeFactory = snowflakeFactory;
 
-		this.redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
-		this.encryption_key = options.key;
-		this.validator = options.validator;
+		this.#redis_key_revoked = `${REDIS_PREFIX}${options.namespace}:revoked`;
+		this.#encryption_key = options.key;
+		this.#validator = options.validator;
 
 		if (options.senml_key_map) {
-			this.cborEncoder = new CborEncoder({
+			this.#cborEncoder = new CborEncoder({
 				keyMap: options.senml_key_map,
 			});
 		}
@@ -95,20 +95,20 @@ export class EcwtFactory<
 			ttl?: number;
 		} = {},
 	): Promise<Ecwt<D>> {
-		if (typeof this.validator === 'function') {
-			data = this.validator(data);
+		if (typeof this.#validator === 'function') {
+			data = this.#validator(data);
 		}
 
 		const ttl = options.ttl ?? null;
-		const snowflake = await this.snowflakeFactory.createSafe();
+		const snowflake = await this.#snowflakeFactory.createSafe();
 		const payload = [snowflake.toBuffer(), ttl, data];
-		const token_raw = this.cborEncoder
-			? this.cborEncoder.encode(payload)
+		const token_raw = this.#cborEncoder
+			? this.#cborEncoder.encode(payload)
 			: cborEncode(payload);
 
 		const token_encrypted = await evilcryptV2.encrypt(
 			token_raw,
-			this.encryption_key,
+			this.#encryption_key,
 		);
 
 		const token = base62.encode(token_encrypted);
@@ -133,7 +133,7 @@ export class EcwtFactory<
 	 * @param cache_value - Data to be stored in cache.
 	 */
 	private setCache(token: string, cache_value: LRUCacheValue) {
-		this.lruCache?.set(
+		this.#lruCache?.set(
 			token,
 			cache_value,
 			cache_value.ttl_initial === null
@@ -158,7 +158,7 @@ export class EcwtFactory<
 		let ttl_initial;
 		let data;
 
-		const cached_entry = this.lruCache?.info(token);
+		const cached_entry = this.#lruCache?.info(token);
 		// token is not cached
 		if (cached_entry === undefined) {
 			const token_encrypted = Buffer.from(base62.decode(token));
@@ -167,24 +167,24 @@ export class EcwtFactory<
 			try {
 				token_raw = await evilcryptDecrypt(
 					token_encrypted,
-					this.encryption_key,
+					this.#encryption_key,
 				);
 			} catch {
 				throw new EcwtParseError();
 			}
 
-			const payload = this.cborEncoder
-				? this.cborEncoder.decode(token_raw)
+			const payload = this.#cborEncoder
+				? this.#cborEncoder.decode(token_raw)
 				: cborDecode(token_raw);
 
 			const [snowflake_buffer] = payload;
 			[, ttl_initial, data] = payload;
 
-			snowflake = this.snowflakeFactory.parse(snowflake_buffer);
+			snowflake = this.#snowflakeFactory.parse(snowflake_buffer);
 
-			if (typeof this.validator === 'function') {
+			if (typeof this.#validator === 'function') {
 				try {
-					data = this.validator(data);
+					data = this.#validator(data);
 				} catch {
 					throw new EcwtParseError();
 				}
@@ -218,8 +218,12 @@ export class EcwtFactory<
 			throw new EcwtExpiredError(ecwt);
 		}
 
-		if (await this.redisClient?.HEXISTS(this.redis_key_revoked, ecwt.id)) {
-			throw new EcwtRevokedError(ecwt);
+		if (this.#redisClient) {
+			await this.#migrateExpired();
+
+			if (await this.#redisClient.HEXISTS(this.#redis_key_revoked, ecwt.id)) {
+				throw new EcwtRevokedError(ecwt);
+			}
 		}
 
 		return ecwt;
@@ -269,29 +273,34 @@ export class EcwtFactory<
 
 	/**
 	 * Revokes token.
+	 * @internal
 	 * @param token_id -
-	 * @param ts_ms_created -
+	 * @param created_at_ms -
 	 * @param ttl_initial -
 	 * @returns -
 	 */
-	private async _revoke(
+	async _revoke(
 		token_id: string,
-		ts_ms_created: number,
+		created_at_ms: number,
 		ttl_initial: number | null,
-	) {
-		if (this.redisClient) {
-			ttl_initial ??= Number.MAX_SAFE_INTEGER;
+	): Promise<void> {
+		if (this.#redisClient) {
+			await this.#migrateExpired();
 
-			const ts_ms_expired = ts_ms_created + ttl_initial * 1000;
-			if (ts_ms_expired > Date.now()) {
-				await this.redisClient.sendCommand([
-					'HSET',
-					this.redis_key_revoked,
-					token_id,
-					'',
-					'PX',
-					String(ts_ms_expired - Date.now()),
-				]);
+			if (ttl_initial === null) {
+				await this.#redisClient.HSET(this.#redis_key_revoked, token_id, '');
+			} else {
+				const expires_in_ms = created_at_ms + ttl_initial * 1000 - Date.now();
+				if (expires_in_ms > 0) {
+					await this.#redisClient.sendCommand([
+						'HSET',
+						this.#redis_key_revoked,
+						token_id,
+						'',
+						'PX',
+						String(expires_in_ms),
+					]);
+				}
 			}
 		} else {
 			// oxlint-disable-next-line no-console
@@ -301,8 +310,27 @@ export class EcwtFactory<
 		}
 	}
 
-	/** Purges LRU cache. */
-	private _purgeCache() {
-		this.lruCache?.clear();
+	#migrated = false;
+
+	async #migrateExpired() {
+		if (this.#redisClient && !this.#migrated) {
+			await this.#redisClient.EVAL(
+				'local key = KEYS[1] if redis.call("TYPE", key)["ok"] ~= "zset" then return end local key_hash = key .. ":hash" local ts_now = tonumber(ARGV[1]) local cursor = "0" repeat local scan = redis.call("ZSCAN", key, cursor, "COUNT", 1000) cursor = scan[1] local items = scan[2] for i = 1, #items, 2 do local field = items[i] local expire_at = tonumber(items[i + 1]) local expire_in = expire_at and expire_at - ts_now redis.call("HSET", key_hash, field, "") if expire_in and expire_in > 0 then redis.call("HPEXPIRE", key_hash, expire_in, "FIELDS", 1, field) end end until cursor == "0" redis.call("DEL", key) redis.call("RENAME", key_hash, key)',
+				{
+					keys: [this.#redis_key_revoked],
+					arguments: [String(Date.now())],
+				},
+			);
+
+			this.#migrated = true;
+		}
+	}
+
+	/**
+	 * @internal
+	 * Purges LRU cache.
+	 */
+	_purgeCache() {
+		this.#lruCache?.clear();
 	}
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -12,8 +12,8 @@ export class Ecwt<
 	readonly snowflake: Snowflake;
 	/** Data stored in token. */
 	readonly data: Readonly<D>;
-	private ecwtFactory: EcwtFactory;
-	private ttl_initial: number | null;
+	#ecwtFactory: EcwtFactory;
+	#ttl_initial: number | null;
 
 	/**
 	 * @param ecwtFactory -
@@ -37,8 +37,8 @@ export class Ecwt<
 		this.snowflake = options.snowflake;
 		this.data = Object.freeze(options.data);
 
-		this.ecwtFactory = ecwtFactory;
-		this.ttl_initial = options.ttl_initial;
+		this.#ecwtFactory = ecwtFactory;
+		this.#ttl_initial = options.ttl_initial;
 	}
 
 	/**
@@ -46,11 +46,11 @@ export class Ecwt<
 	 * @returns -
 	 */
 	get ts_expired(): number | null {
-		if (this.ttl_initial === null) {
+		if (this.#ttl_initial === null) {
 			return null;
 		}
 
-		return Math.floor(this.snowflake.timestamp / 1000) + this.ttl_initial;
+		return Math.floor(this.snowflake.timestamp / 1000) + this.#ttl_initial;
 	}
 
 	/**
@@ -58,23 +58,22 @@ export class Ecwt<
 	 * @returns -
 	 */
 	getTTL(): number | null {
-		if (this.ttl_initial === null) {
+		if (this.#ttl_initial === null) {
 			return null;
 		}
 
 		return (
-			this.ttl_initial
+			this.#ttl_initial
 			- Math.floor((Date.now() - this.snowflake.timestamp) / 1000)
 		);
 	}
 
 	/** Revokes token. */
 	revoke(): Promise<void> {
-		// @ts-expect-error Accessing private method
-		return this.ecwtFactory._revoke(
+		return this.#ecwtFactory._revoke(
 			this.id,
 			this.snowflake.timestamp,
-			this.ttl_initial,
+			this.#ttl_initial,
 		);
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
 		"lib": ["es2022"],
 		"types": ["*"],
 		"declaration": true,
-		"isolatedDeclarations": true
+		"isolatedDeclarations": true,
+		"stripInternal": true
 	},
 	"include": ["src/"],
 	"exclude": ["dist/", "node_modules/"]


### PR DESCRIPTION
- add lua script that migrates revoked tokens storage from 0.2's zset to 0.3's hash with expiration
- make private methods private in JS using #
- remove usage of private methods, hiding them from types with `@internal` JSDoc